### PR TITLE
VS Code: Work around inlay hint display bug

### DIFF
--- a/server/src/documentAnnotations.ts
+++ b/server/src/documentAnnotations.ts
@@ -32,7 +32,7 @@ export const getAnnotatedDocument = (
     textDocument: document,
     sdk,
     completionType,
-    methodLocations: documentAnnotations[document.uri]?.methodLocations || [],
+    methodLocations: documentAnnotations[document.uri]?.methodLocations ?? [],
   };
 };
 

--- a/server/src/inlayHints/index.ts
+++ b/server/src/inlayHints/index.ts
@@ -3,6 +3,8 @@ import { InlayHintAnalyzer, InlayHintAnalyzerArgs } from "../types";
 
 import overrides from "./overrides";
 
+const ZERO_WIDTH_SPACE = "​";
+
 export const inlayHints: InlayHintAnalyzer[] = [overrides];
 
 export const runAllInlayHints = async (
@@ -13,4 +15,12 @@ export const runAllInlayHints = async (
   );
 
   return allInlayHints.flat();
+};
+
+export const NULL_HINT: InlayHint = {
+  label: ZERO_WIDTH_SPACE,
+  position: {
+    line: 0,
+    character: Number.MAX_SAFE_INTEGER,
+  },
 };

--- a/server/src/inlayHints/overrides.ts
+++ b/server/src/inlayHints/overrides.ts
@@ -13,7 +13,7 @@ const overrides: InlayHintAnalyzer = async ({
   log,
 }: InlayHintAnalyzerArgs) => {
   log("InlayHint", {
-    overrides: document.methodLocations,
+    methodLocations: document.methodLocations,
   });
 
   return document.methodLocations

--- a/server/src/prefabClient.ts
+++ b/server/src/prefabClient.ts
@@ -214,21 +214,25 @@ export const prefabInit = ({
 }) => {
   log("PrefabClient", "Initializing Prefab client");
 
-  prefab = new Prefab({
-    apiKey,
-    apiUrl: apiUrlOrDefault({ apiUrl }),
-    enableSSE: true,
-    defaultLogLevel: "warn",
-    fetch,
-    onUpdate: () => {
-      log("PrefabClient", "Prefab client updated");
-      internalOnUpdate(log);
-      log("PrefabClient", { overrides });
-      onUpdate();
-    },
-  });
+  prefabPromise = new Promise((resolve) => {
+    prefab = new Prefab({
+      apiKey,
+      apiUrl: apiUrlOrDefault({ apiUrl }),
+      enableSSE: true,
+      defaultLogLevel: "warn",
+      fetch,
+      onUpdate: () => {
+        log("PrefabClient", "Prefab client updated");
+        internalOnUpdate(log);
+        log("PrefabClient", { overrides });
+        onUpdate();
 
-  prefabPromise = prefab.init();
+        resolve();
+      },
+    });
+
+    prefab.init();
+  });
 };
 
 type ProjectEnvId = {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -205,4 +205,5 @@ export type CodeActionAnalyzerArgs = {
 export type ClientContext = {
   capabilities: ClientCapabilities;
   customHandlers: CustomHandlerValue[];
+  editorIdentifier: "vscode" | "other";
 };


### PR DESCRIPTION
If VS Code opens a document with no inlay hints visible, it won't
request new inlay hints until the code window is redrawn. This happens
even if you issue `workspace/inlayHint/refresh`

To work around this, we set a zero-width space hint in the document when
no hints would otherwise be shown. This behavior is VS Code only.

This changeset also makes the `prefabPromise` only be settled after the
`onUpdate` fires. This should prevent some race conditions down the
line.
