### PR TITLE
Add minimal caching to prevent duplicate work

### DIFF
--- a/server/src/documentAnnotations.ts
+++ b/server/src/documentAnnotations.ts
@@ -10,12 +10,17 @@ import type {
 export const documentAnnotations: Record<string, DocumentAnnotations> = {};
 
 export const annotateDocument = (document: TextDocument) => {
+  if (documentAnnotations[document.uri]?.version === document.version) {
+    return;
+  }
+
   const sdk = detectSDK(document);
 
   const methodLocations = sdk.detectMethods(document);
 
   documentAnnotations[document.uri] = {
     methodLocations,
+    version: document.version,
   };
 };
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -192,6 +192,7 @@ export type HoverAnalyzer = (args: HoverAnalyzerArgs) => Promise<Hover | null>;
 
 export type DocumentAnnotations = {
   methodLocations: MethodLocation[];
+  version: TextDocument["version"];
 };
 
 export type AnnotatedDocument = {


### PR DESCRIPTION
- Unify `ready` to be a single promise versus multiple config gets
- Don't `annotateDocument` multiple consecutive times on same version
- Don't issue an `update` for the same document version multiple times in a row