### PR TITLE
Allow completion of keys that are partially typed

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -12,7 +12,7 @@ let client: LanguageClient;
 export function activate(context: ExtensionContext) {
   // The server is implemented in node
   const serverModule = context.asAbsolutePath(
-    path.join("server", "out", "server.js")
+    path.join("server", "out", "server.js"),
   );
 
   // If the extension is launched in debug mode then the debug server options are used
@@ -44,7 +44,7 @@ export function activate(context: ExtensionContext) {
     "prefab-language-server",
     "Prefab",
     serverOptions,
-    clientOptions
+    clientOptions,
   );
 
   client.onRequest(
@@ -56,7 +56,7 @@ export function activate(context: ExtensionContext) {
       });
 
       return option;
-    }
+    },
   );
 
   client.onRequest(
@@ -76,7 +76,7 @@ export function activate(context: ExtensionContext) {
       return {
         input,
       };
-    }
+    },
   );
 
   // Start the client. This will also launch the server

--- a/server/src/completions/keys.test.ts
+++ b/server/src/completions/keys.test.ts
@@ -2,15 +2,19 @@ import { describe, expect, it } from "bun:test";
 import { CompletionItemKind } from "vscode-languageserver/node";
 
 import { log, mkAnnotatedDocument } from "../testHelpers";
-import { CompletionType, type CompletionTypeValue } from "../types";
+import {
+  CompletionType,
+  type CompletionTypeValue,
+  CompletionTypeWithPrefix,
+} from "../types";
 import keys from "./keys";
 
 const providedKeysForCompletionType = async (
-  type: CompletionTypeValue | null
+  type: CompletionTypeValue | null,
 ) => {
   switch (type) {
     case CompletionType.BOOLEAN_FEATURE_FLAGS:
-      return ["flag1", "flag2"];
+      return ["flag1", "flag2", "another-flag"];
     case CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS:
       return ["config1", "config2", "wordy-flag"];
     default:
@@ -20,12 +24,18 @@ const providedKeysForCompletionType = async (
 
 describe("keys", () => {
   it("can return flag keys", async () => {
-    const completionType = (): CompletionTypeValue | null =>
-      CompletionType.BOOLEAN_FEATURE_FLAGS;
+    const completionTypeWithPrefix = (): CompletionTypeWithPrefix | null => {
+      return {
+        completionType: CompletionType.BOOLEAN_FEATURE_FLAGS,
+        prefix: "",
+      };
+    };
 
     const position = { line: 3, character: 20 };
 
-    const document = mkAnnotatedDocument({ completionType });
+    const document = mkAnnotatedDocument({
+      completionTypeWithPrefix: completionTypeWithPrefix,
+    });
 
     const results = await keys({
       position,
@@ -39,23 +49,35 @@ describe("keys", () => {
         label: "flag1",
         kind: CompletionItemKind.Constant,
         data: "flag1",
+        insertText: "flag1",
       },
       {
         label: "flag2",
         kind: CompletionItemKind.Constant,
         data: "flag2",
+        insertText: "flag2",
+      },
+      {
+        label: "another-flag",
+        kind: CompletionItemKind.Constant,
+        data: "another-flag",
+        insertText: "another-flag",
       },
     ]);
   });
 
   it("can return config keys", async () => {
-    const completionType = (): CompletionTypeValue | null =>
-      CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS;
+    const completionTypeWithPrefix = (): CompletionTypeWithPrefix | null => {
+      return {
+        completionType: CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+        prefix: "",
+      };
+    };
 
     const position = { line: 7, character: 18 };
 
     const document = mkAnnotatedDocument({
-      completionType,
+      completionTypeWithPrefix: completionTypeWithPrefix,
     });
 
     const results = await keys({
@@ -70,16 +92,93 @@ describe("keys", () => {
         label: "config1",
         kind: CompletionItemKind.Constant,
         data: "config1",
+        insertText: "config1",
       },
       {
         label: "config2",
         kind: CompletionItemKind.Constant,
         data: "config2",
+        insertText: "config2",
       },
       {
         label: "wordy-flag",
         kind: CompletionItemKind.Constant,
         data: "wordy-flag",
+        insertText: "wordy-flag",
+      },
+    ]);
+  });
+
+  it("can return flag keys filtered by the already-typed prefix", async () => {
+    const completionTypeWithPrefix = (): CompletionTypeWithPrefix | null => {
+      return {
+        completionType: CompletionType.BOOLEAN_FEATURE_FLAGS,
+        prefix: "f",
+      };
+    };
+
+    const position = { line: 3, character: 20 };
+
+    const document = mkAnnotatedDocument({
+      completionTypeWithPrefix: completionTypeWithPrefix,
+    });
+
+    const results = await keys({
+      position,
+      document,
+      providedKeysForCompletionType,
+      log,
+    });
+
+    expect(results).toStrictEqual([
+      {
+        label: "flag1",
+        kind: CompletionItemKind.Constant,
+        data: "flag1",
+        insertText: "lag1",
+      },
+      {
+        label: "flag2",
+        kind: CompletionItemKind.Constant,
+        data: "flag2",
+        insertText: "lag2",
+      },
+    ]);
+  });
+
+  it("can return config keys filtered by the already-typed prefix", async () => {
+    const completionTypeWithPrefix = (): CompletionTypeWithPrefix | null => {
+      return {
+        completionType: CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+        prefix: "c",
+      };
+    };
+
+    const position = { line: 7, character: 18 };
+
+    const document = mkAnnotatedDocument({
+      completionTypeWithPrefix: completionTypeWithPrefix,
+    });
+
+    const results = await keys({
+      position,
+      document,
+      providedKeysForCompletionType,
+      log,
+    });
+
+    expect(results).toStrictEqual([
+      {
+        label: "config1",
+        kind: CompletionItemKind.Constant,
+        data: "config1",
+        insertText: "onfig1",
+      },
+      {
+        label: "config2",
+        kind: CompletionItemKind.Constant,
+        data: "config2",
+        insertText: "onfig2",
       },
     ]);
   });
@@ -87,7 +186,9 @@ describe("keys", () => {
   it("returns an empty array if there's no identifiable FF or Config method", async () => {
     const position = { line: 1, character: 10 };
 
-    const document = mkAnnotatedDocument({ completionType: () => null });
+    const document = mkAnnotatedDocument({
+      completionTypeWithPrefix: () => null,
+    });
 
     const results = await keys({
       position,

--- a/server/src/completions/keys.ts
+++ b/server/src/completions/keys.ts
@@ -15,13 +15,19 @@ const onCompletion = async ({
 }: CompletionAnalyzerArgs & Dependencies) => {
   log("Completion", { name: "keys" });
 
-  const completionType = document.completionType(position);
+  const completionTypeWithPrefix = document.completionTypeWithPrefix(position);
 
-  log("Completion", { completionType });
+  log("Completion", { completionTypeWithPrefix });
 
-  const configKeys = await (
-    providedKeysForCompletionType ?? keysForCompletionType
-  )(completionType);
+  if (!completionTypeWithPrefix) {
+    return [];
+  }
+
+  const configKeys = (
+    await (providedKeysForCompletionType ?? keysForCompletionType)(
+      completionTypeWithPrefix.completionType,
+    )
+  ).filter((key) => key.startsWith(completionTypeWithPrefix.prefix));
 
   log("Completion", { configKeys });
 
@@ -30,6 +36,7 @@ const onCompletion = async ({
       label: name,
       kind: CompletionItemKind.Constant,
       data: name,
+      insertText: name.replace(completionTypeWithPrefix.prefix, ""),
     };
   });
 };

--- a/server/src/documentAnnotations.ts
+++ b/server/src/documentAnnotations.ts
@@ -25,7 +25,7 @@ export const annotateDocument = (document: TextDocument) => {
 };
 
 export const getAnnotatedDocument = (
-  document: TextDocument
+  document: TextDocument,
 ): AnnotatedDocument => {
   const sdk = detectSDK(document);
 
@@ -37,14 +37,14 @@ export const getAnnotatedDocument = (
     uri: document.uri,
     textDocument: document,
     sdk,
-    completionType,
+    completionTypeWithPrefix: completionType,
     methodLocations: documentAnnotations[document.uri]?.methodLocations ?? [],
   };
 };
 
 export const methodAtPosition = (
   document: AnnotatedDocument,
-  position: Position
+  position: Position,
 ): MethodLocation | undefined => {
   const location = document.methodLocations.find((method) => {
     return (

--- a/server/src/hovers/index.test.ts
+++ b/server/src/hovers/index.test.ts
@@ -30,7 +30,7 @@ describe("runAllHovers", () => {
     const filterForMissingKeys = async () => [];
 
     const document = mkAnnotatedDocument({
-      completionType: () => null,
+      completionTypeWithPrefix: () => null,
       methodLocations: [
         {
           key: "redis.connection-string",

--- a/server/src/sdks/common.ts
+++ b/server/src/sdks/common.ts
@@ -26,7 +26,7 @@ const METHOD_KEYS: MethodTypeKeys[] = [
 export const detectMethod = (
   document: TextDocument,
   position: Position,
-  regexes: DetectMethodRegex
+  regexes: DetectMethodRegex,
 ): MethodTypeValue | null => {
   const line = lineFromStartToPosition(document, position);
 
@@ -45,10 +45,30 @@ export const detectMethod = (
   return null;
 };
 
+export const prefixAt = (
+  document: TextDocument,
+  position: Position,
+  regex: RegExp,
+): string => {
+  const line = lineFromStartToPosition(document, position);
+
+  if (!line) {
+    return "";
+  }
+
+  const match = line.match(regex);
+
+  if (!match) {
+    return "";
+  }
+
+  return match[1] ?? "";
+};
+
 export const detectProvidable = (
   document: TextDocument,
   position: Position,
-  regex: RegExp
+  regex: RegExp,
 ): KeyLocation | undefined => {
   const text = document.getText();
 
@@ -61,7 +81,7 @@ export const detectProvidable = (
 
 export const detectMethods = (
   document: TextDocument,
-  regexes: DetectMethodsRegex
+  regexes: DetectMethodsRegex,
 ): MethodLocation[] => {
   const result: MethodLocation[] = [];
 

--- a/server/src/sdks/detection.ts
+++ b/server/src/sdks/detection.ts
@@ -1,7 +1,7 @@
 import { Position, TextDocument } from "vscode-languageserver-textdocument";
 
 import {
-  CompletionTypeValue,
+  CompletionTypeWithPrefix,
   KeyLocation,
   MethodLocation,
   MethodTypeValue,
@@ -39,7 +39,7 @@ export type SDK = {
   completionType: (
     document: TextDocument,
     position: Position,
-  ) => CompletionTypeValue | null;
+  ) => CompletionTypeWithPrefix | null;
   configGet: (key: string) => string;
 };
 

--- a/server/src/sdks/java.test.ts
+++ b/server/src/sdks/java.test.ts
@@ -58,7 +58,7 @@ describe("JavaSDK", () => {
         const document = mkDocument({ text });
 
         expect(JavaSDK.detectMethod(document, position)).toEqual(
-          MethodType.IS_ENABLED
+          MethodType.IS_ENABLED,
         );
       });
     });
@@ -68,7 +68,7 @@ describe("JavaSDK", () => {
         const document = mkDocument({ text });
 
         expect(JavaSDK.detectMethod(document, position)).toEqual(
-          MethodType.GET
+          MethodType.GET,
         );
       });
     });
@@ -103,9 +103,10 @@ describe("JavaSDK", () => {
       FF_EXAMPLES.forEach(([text, position]) => {
         const document = mkDocument({ text });
 
-        expect(JavaSDK.completionType(document, position)).toEqual(
-          CompletionType.BOOLEAN_FEATURE_FLAGS
-        );
+        expect(JavaSDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
       });
     });
 
@@ -113,9 +114,45 @@ describe("JavaSDK", () => {
       CONFIG_EXAMPLES.forEach(([text, position]) => {
         const document = mkDocument({ text });
 
-        expect(JavaSDK.completionType(document, position)).toEqual(
-          CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS
-        );
+        expect(JavaSDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
+      });
+    });
+
+    it("can complete mid-word", () => {
+      const examples: [string, Position, string][] = [
+        [
+          '.liveString("ap")',
+          { line: 0, character: 15 },
+          CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+        ],
+        [
+          '.featureIsOn("ap")',
+          { line: 0, character: 16 },
+          CompletionType.BOOLEAN_FEATURE_FLAGS,
+        ],
+      ];
+
+      examples.forEach(([text, position, expectedType]) => {
+        const document = mkDocument({ text });
+        expect(JavaSDK.completionType(document, position)).toEqual({
+          completionType: expectedType,
+          prefix: "ap",
+        });
+      });
+    });
+
+    it("won't complete from outside the key", () => {
+      const examples: ExampleStringAndPosition[] = [
+        ['.liveString("ap")', { line: 0, character: 16 }],
+        ['.featureIsOn("ap")', { line: 0, character: 17 }],
+      ];
+
+      examples.forEach(([text, position]) => {
+        const document = mkDocument({ text });
+        expect(JavaSDK.completionType(document, position)).toBeNull();
       });
     });
 

--- a/server/src/sdks/java.ts
+++ b/server/src/sdks/java.ts
@@ -2,7 +2,7 @@ import { Position, TextDocument } from "vscode-languageserver-textdocument";
 
 import {
   CompletionType,
-  CompletionTypeValue,
+  CompletionTypeWithPrefix,
   MethodLocation,
   MethodType,
   MethodTypeValue,
@@ -12,6 +12,7 @@ import {
   type DetectMethodRegex,
   detectMethods,
   type DetectMethodsRegex,
+  prefixAt,
 } from "./common";
 import { type SDK } from "./detection";
 
@@ -23,8 +24,8 @@ const METHOD_REGEXES: DetectMethodsRegex = {
 };
 
 const DETECT_METHOD_REGEXES: DetectMethodRegex = {
-  IS_ENABLED: /\.featureIsOn\(["']$/,
-  GET: /\.(?:get|liveString|liveStringList|liveBoolean|liveLong|liveDouble)\(["']$/,
+  IS_ENABLED: /\.featureIsOn\(["']([^)"']*)$/,
+  GET: /\.(?:get|liveString|liveStringList|liveBoolean|liveLong|liveDouble)\(["']([^)"']*)$/,
 };
 
 const JavaSDK: SDK = {
@@ -36,7 +37,7 @@ const JavaSDK: SDK = {
 
   detectMethod: (
     document: TextDocument,
-    position: Position
+    position: Position,
   ): MethodTypeValue | null => {
     return detectMethod(document, position, DETECT_METHOD_REGEXES);
   },
@@ -47,16 +48,20 @@ const JavaSDK: SDK = {
 
   completionType: (
     document: TextDocument,
-    position: Position
-  ): CompletionTypeValue | null => {
-    switch (JavaSDK.detectMethod(document, position)) {
-      case MethodType.IS_ENABLED:
-        return CompletionType.BOOLEAN_FEATURE_FLAGS;
-      case MethodType.GET:
-        return CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS;
-      default:
-        return null;
+    position: Position,
+  ): CompletionTypeWithPrefix | null => {
+    const methodType = JavaSDK.detectMethod(document, position);
+    if (methodType === null) {
+      return null;
     }
+
+    return {
+      completionType:
+        methodType === MethodType.IS_ENABLED
+          ? CompletionType.BOOLEAN_FEATURE_FLAGS
+          : CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+      prefix: prefixAt(document, position, DETECT_METHOD_REGEXES[methodType]),
+    };
   },
 
   configGet: (key: string): string => {

--- a/server/src/sdks/javascript.test.ts
+++ b/server/src/sdks/javascript.test.ts
@@ -55,7 +55,7 @@ describe("JavascriptSDK", () => {
         const document = mkDocument({ text });
 
         expect(JavascriptSDK.detectMethod(document, position)).toEqual(
-          MethodType.IS_ENABLED
+          MethodType.IS_ENABLED,
         );
       });
     });
@@ -65,7 +65,7 @@ describe("JavascriptSDK", () => {
         const document = mkDocument({ text });
 
         expect(JavascriptSDK.detectMethod(document, position)).toEqual(
-          MethodType.GET
+          MethodType.GET,
         );
       });
     });
@@ -100,9 +100,10 @@ describe("JavascriptSDK", () => {
       FF_EXAMPLES.forEach(([text, position]) => {
         const document = mkDocument({ text });
 
-        expect(JavascriptSDK.completionType(document, position)).toEqual(
-          CompletionType.BOOLEAN_FEATURE_FLAGS
-        );
+        expect(JavascriptSDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
       });
     });
 
@@ -110,9 +111,45 @@ describe("JavascriptSDK", () => {
       CONFIG_EXAMPLES.forEach(([text, position]) => {
         const document = mkDocument({ text });
 
-        expect(JavascriptSDK.completionType(document, position)).toEqual(
-          CompletionType.NON_BOOLEAN_FEATURE_FLAGS
-        );
+        expect(JavascriptSDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.NON_BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
+      });
+    });
+
+    it("can complete mid-word", () => {
+      const examples: [string, Position, string][] = [
+        [
+          'prefab.get("ap")',
+          { line: 0, character: 14 },
+          CompletionType.NON_BOOLEAN_FEATURE_FLAGS,
+        ],
+        [
+          'prefab.isEnabled("ap")',
+          { line: 0, character: 20 },
+          CompletionType.BOOLEAN_FEATURE_FLAGS,
+        ],
+      ];
+
+      examples.forEach(([text, position, expectedType]) => {
+        const document = mkDocument({ text });
+        expect(JavascriptSDK.completionType(document, position)).toEqual({
+          completionType: expectedType,
+          prefix: "ap",
+        });
+      });
+    });
+
+    it("won't complete from outside the key", () => {
+      const examples: ExampleStringAndPosition[] = [
+        ['prefab.get("ap")', { line: 0, character: 15 }],
+        ['prefab.isEnabled("ap")', { line: 0, character: 21 }],
+      ];
+
+      examples.forEach(([text, position]) => {
+        const document = mkDocument({ text });
+        expect(JavascriptSDK.completionType(document, position)).toBeNull();
       });
     });
 

--- a/server/src/sdks/python.test.ts
+++ b/server/src/sdks/python.test.ts
@@ -56,7 +56,7 @@ describe("PythonSDK", () => {
         const document = mkDocument({ text });
 
         expect(PythonSDK.detectMethod(document, position)).toEqual(
-          MethodType.IS_ENABLED
+          MethodType.IS_ENABLED,
         );
       });
     });
@@ -66,7 +66,7 @@ describe("PythonSDK", () => {
         const document = mkDocument({ text });
 
         expect(PythonSDK.detectMethod(document, position)).toEqual(
-          MethodType.GET
+          MethodType.GET,
         );
       });
     });
@@ -101,9 +101,10 @@ describe("PythonSDK", () => {
       it(`returns flag names for \`${text}\``, () => {
         const document = mkDocument({ text });
 
-        expect(PythonSDK.completionType(document, position)).toEqual(
-          CompletionType.BOOLEAN_FEATURE_FLAGS
-        );
+        expect(PythonSDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
       });
     });
 
@@ -111,9 +112,45 @@ describe("PythonSDK", () => {
       it(`returns config and non-boolean flag names for \`${text}\``, () => {
         const document = mkDocument({ text });
 
-        expect(PythonSDK.completionType(document, position)).toEqual(
-          CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS
-        );
+        expect(PythonSDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
+      });
+    });
+
+    it("can complete mid-word", () => {
+      const examples: [string, Position, string][] = [
+        [
+          'prefab.get("ap")',
+          { line: 0, character: 14 },
+          CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+        ],
+        [
+          'prefab.enabled("ap")',
+          { line: 0, character: 18 },
+          CompletionType.BOOLEAN_FEATURE_FLAGS,
+        ],
+      ];
+
+      examples.forEach(([text, position, expectedType]) => {
+        const document = mkDocument({ text });
+        expect(PythonSDK.completionType(document, position)).toEqual({
+          completionType: expectedType,
+          prefix: "ap",
+        });
+      });
+    });
+
+    it("won't complete from outside the key", () => {
+      const examples: ExampleStringAndPosition[] = [
+        ['prefab.get("no")', { line: 0, character: 15 }],
+        ['prefab.enabled("no")', { line: 0, character: 19 }],
+      ];
+
+      examples.forEach(([text, position]) => {
+        const document = mkDocument({ text });
+        expect(PythonSDK.completionType(document, position)).toBeNull();
       });
     });
 

--- a/server/src/sdks/ruby.test.ts
+++ b/server/src/sdks/ruby.test.ts
@@ -101,7 +101,7 @@ describe("RubySDK", () => {
         const document = mkDocument({ text });
 
         expect(RubySDK.detectMethod(document, position)).toEqual(
-          MethodType.IS_ENABLED
+          MethodType.IS_ENABLED,
         );
       });
     });
@@ -111,7 +111,7 @@ describe("RubySDK", () => {
         const document = mkDocument({ text });
 
         expect(RubySDK.detectMethod(document, position)).toEqual(
-          MethodType.GET
+          MethodType.GET,
         );
       });
     });
@@ -146,9 +146,10 @@ describe("RubySDK", () => {
       it(`returns flag names for \`${text}\``, () => {
         const document = mkDocument({ text });
 
-        expect(RubySDK.completionType(document, position)).toEqual(
-          CompletionType.BOOLEAN_FEATURE_FLAGS
-        );
+        expect(RubySDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
       });
     });
 
@@ -156,9 +157,45 @@ describe("RubySDK", () => {
       it(`returns config and non-boolean flag names for \`${text}\``, () => {
         const document = mkDocument({ text });
 
-        expect(RubySDK.completionType(document, position)).toEqual(
-          CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS
-        );
+        expect(RubySDK.completionType(document, position)).toEqual({
+          completionType: CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+          prefix: "",
+        });
+      });
+    });
+
+    it("can complete mid-word", () => {
+      const examples: [string, Position, string][] = [
+        [
+          'prefab.get("ap")',
+          { line: 0, character: 14 },
+          CompletionType.CONFIGS_AND_NON_BOOLEAN_FEATURE_FLAGS,
+        ],
+        [
+          'prefab.enabled?("ap")',
+          { line: 0, character: 19 },
+          CompletionType.BOOLEAN_FEATURE_FLAGS,
+        ],
+      ];
+
+      examples.forEach(([text, position, expectedType]) => {
+        const document = mkDocument({ text });
+        expect(RubySDK.completionType(document, position)).toEqual({
+          completionType: expectedType,
+          prefix: "ap",
+        });
+      });
+    });
+
+    it("won't complete from outside the key", () => {
+      const examples: ExampleStringAndPosition[] = [
+        ['prefab.get("no")', { line: 0, character: 15 }],
+        ['prefab.enabled?("no")', { line: 0, character: 20 }],
+      ];
+
+      examples.forEach(([text, position]) => {
+        const document = mkDocument({ text });
+        expect(RubySDK.completionType(document, position)).toBeNull();
       });
     });
 

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -66,6 +66,8 @@ const getSettings = async (
     log("Settings", "Using API key from settings");
   }
 
+  log("Settings", newSettings);
+
   newSettings.envVars = envVars;
 
   updateSettings(connection, newSettings, log, refresh, refreshApiClient);

--- a/server/src/testHelpers.ts
+++ b/server/src/testHelpers.ts
@@ -21,13 +21,13 @@ type NewDoc = {
 };
 
 export const mkAnnotatedDocument = (
-  args: Partial<AnnotatedDocument>
+  args: Partial<AnnotatedDocument>,
 ): AnnotatedDocument => {
   return {
     uri: args.uri ?? defaultUriForTests,
     textDocument: args.textDocument ?? mkDocument({}),
     methodLocations: args.methodLocations ?? [],
-    completionType: args.completionType ?? (() => null),
+    completionTypeWithPrefix: args.completionTypeWithPrefix ?? (() => null),
     sdk: args.sdk ?? NullSDK,
   };
 };
@@ -37,7 +37,7 @@ export const mkDocument = (doc: Partial<NewDoc>): TextDocument => {
     doc.uri ?? defaultUriForTests,
     doc.languageId ?? "some-language",
     doc.version ?? 1,
-    doc.text ?? "some text"
+    doc.text ?? "some text",
   );
 };
 
@@ -67,7 +67,7 @@ export type SimpleResponse = {
 };
 
 export const mockRequest = (
-  requestOrRequests: SimpleResponse | SimpleResponse[]
+  requestOrRequests: SimpleResponse | SimpleResponse[],
 ) => {
   const requests = Array.isArray(requestOrRequests)
     ? requestOrRequests

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -82,7 +82,7 @@ export type CompletionTypeValue =
 export const MethodType = {
   GET: "GET",
   IS_ENABLED: "IS_ENABLED",
-};
+} as const;
 
 export type MethodTypeKeys = keyof typeof MethodType;
 
@@ -188,10 +188,17 @@ export type DocumentAnnotations = {
   version: TextDocument["version"];
 };
 
+export type CompletionTypeWithPrefix = {
+  completionType: CompletionTypeValue;
+  prefix: string;
+};
+
 export type AnnotatedDocument = {
   uri: string;
   textDocument: TextDocument;
-  completionType: (position: Position) => CompletionTypeValue | null;
+  completionTypeWithPrefix: (
+    position: Position,
+  ) => CompletionTypeWithPrefix | null;
   methodLocations: MethodLocation[];
   sdk: SDK;
 };


### PR DESCRIPTION
e.g., completing `Prefab.get("rate")` from the end of `rate` to get the
suggestion `ratelimit.xyz`
